### PR TITLE
Fix PHP page file path mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# nginxPHPcertbot
+# nginx PHP Test Setup
+
+This repository contains a simple Docker Compose setup with two containers:
+
+- **nginx** – serves a PHP-based test page
+- **php** – runs the PHP-FPM interpreter
+
+## Usage
+
+1. Build and start the containers using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+2. Open `http://localhost` in your browser to see the test page displaying the PHP version.
+

--- a/app/index.php
+++ b/app/index.php
@@ -1,0 +1,3 @@
+<?php
+    echo "Hallo von PHP ueber nginx! PHP-Version: " . phpversion();
+?>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  php:
+    build:
+      context: .
+      dockerfile: php/Dockerfile
+    container_name: php
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+    ports:
+      - "80:80"
+    depends_on:
+      - php
+    container_name: nginx

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY app /var/www/html

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass php:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_index index.php;
+    }
+}

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:8.2-fpm-alpine
+WORKDIR /var/www/html
+COPY app /var/www/html


### PR DESCRIPTION
## Summary
- update nginx Dockerfile to copy PHP files to /var/www/html
- set nginx config root to /var/www/html so PHP container sees the same path

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cf471bc1c8323951199575f609ed2